### PR TITLE
Look for Firefox in HKCU as well as HKLM (fix #73)

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -74,41 +74,41 @@ function normalizeBinary (binaryPath, platform, arch) {
     // Windows binary finding
     var appName = normalizeBinary.appNames[app + " on windows"];
 
-    // this is used when reading the registry goes wrong.
-    function fallBack () {
+    resolve(getPathToExe(Winreg.HKCU, appName).catch(function() {
+      return getPathToExe(Winreg.HKLM, appName);
+    }).catch(function() {
+      // Neither registry hive has the correct keys
       var programFilesVar = "ProgramFiles";
       if (arch === "(64)") {
         console.warn("You are using 32-bit version of Firefox on 64-bit versions of the Windows.\nSome features may not work correctly in this version. You should upgrade Firefox to the latest 64-bit version now!")
         programFilesVar = "ProgramFiles(x86)";
       }
-      resolve(path.join(process.env[programFilesVar], appName, "firefox.exe"));
-    }
+      return path.join(process.env[programFilesVar], appName, "firefox.exe");
+    }));
+  });
+}
 
-    var rootKey = "\\Software\\Mozilla\\";
-    rootKey = path.join(rootKey, appName);
+// Returns a promise to get Firefox's PathToExe from a registry hive
+function getPathToExe(hive, appName) {
+  const rootKey = path.join("\\Software\\Mozilla\\", appName);
 
-    return when.promise(function(resolve, reject) {
-      var versionKey = new Winreg({
-        hive: Winreg.HKLM,
-        key: rootKey
-      });
-      versionKey.get("CurrentVersion", function(err, key) {
-        var isOk = key && !err;
-        return isOk ? resolve(key.value) : reject();
-      });
-    }).then(function(version) {
-      var mainKey = new Winreg({
-        hive: Winreg.HKLM,
-        key: path.join(rootKey, version, "Main")
-      });
-      mainKey.get("PathToExe", function(err, key) {
-        if (err) {
-          fallBack();
-          return;
-        }
-        resolve(key.value);
-      });
-    }, fallBack);
+  return getRegistryValue(hive, rootKey, "CurrentVersion").then(function(version) {
+    return getRegistryValue(hive, path.join(rootKey, version, "Main"), "PathToExe");
+  });
+}
+
+// Returns a promise to get a single registry value
+function getRegistryValue(hive, key, name) {
+  return when.promise(function(resolve, reject) {
+    const registry = new Winreg({ hive, key });
+
+    registry.get(name, function(error, result) {
+      if (result && !error) {
+        resolve(result.value);
+      } else {
+        reject(error);
+      }
+    });
   });
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -102,9 +102,9 @@ function getRegistryValue(hive, key, name) {
   return when.promise(function(resolve, reject) {
     const registry = new Winreg({ hive, key });
 
-    registry.get(name, function(error, result) {
-      if (result && !error) {
-        resolve(result.value);
+    registry.get(name, function(error, resultKey) {
+      if (resultKey && !error) {
+        resolve(resultKey.value);
       } else {
         reject(error);
       }

--- a/test/run/test.utils.js
+++ b/test/run/test.utils.js
@@ -38,7 +38,9 @@ describe("lib/utils", function () {
     var expected = "fake\\binary\\path";
 
     // see ./mock-winreg.js
-    // Only mock keys in HKLM (local machine) hive
+    // Only mock keys in HKLM (local machine) hive.
+    // This test case checks the basic functionality if the user does not have a newer version of
+    // Firefox installed meaning the HKCU keys are not present.
     var winreg = function(options) {
       this.get = function(_, fn) {
         if (options.hive === winreg.HKLM) {
@@ -73,12 +75,13 @@ describe("lib/utils", function () {
       return;
     }
 
-    // Provide different paths depending on hive
+    // Provide different paths depending on hive.
+    // This test case checks that in order to find recent versions of Firefox, HKCU is tried
+    // before falling back on HKCU as in the test above.
     var expected = "fake\\binary\\path";
     var oldPath = "fake\\old\\binary\\path";
 
     // see ./mock-winreg.js
-    // Only mock keys in HKLM (local machine) hive
     var winreg = function(options) {
       this.get = function(_, fn) {
         if (options.hive === winreg.HKCU) {

--- a/test/run/test.utils.js
+++ b/test/run/test.utils.js
@@ -48,7 +48,7 @@ describe("lib/utils", function () {
         }
       };
     };
-    winreg.HKLM = 1;
+    winreg.HKLM = "HKLM";
 
     var binary = sandbox.require("../../lib/utils", {
       requires: { winreg }
@@ -91,8 +91,8 @@ describe("lib/utils", function () {
       };
     };
     // Differentiate hives
-    winreg.HKLM = 1;
-    winreg.HKCU = 2;
+    winreg.HKLM = "HKLM";
+    winreg.HKCU = "HKCU";
 
     var binary = sandbox.require("../../lib/utils", {
       requires: { winreg }

--- a/test/run/test.utils.js
+++ b/test/run/test.utils.js
@@ -35,14 +35,23 @@ describe("lib/utils", function () {
       return;
     }
 
-    // see ./mock-winreg.js
     var expected = "fake\\binary\\path";
-    var binary = sandbox.require("../../lib/utils", {
-      requires: {"winreg": function() {
-        this.get = function(_, fn) {
+
+    // see ./mock-winreg.js
+    // Only mock keys in HKLM (local machine) hive
+    var winreg = function(options) {
+      this.get = function(_, fn) {
+        if (options.hive === winreg.HKLM) {
           fn(null, {value: expected});
-        };
-      }}
+        } else {
+          fn("Failed", null);
+        }
+      };
+    };
+    winreg.HKLM = 1;
+
+    var binary = sandbox.require("../../lib/utils", {
+      requires: { winreg }
     }).normalizeBinary;
 
     var promises = [


### PR DESCRIPTION
Fix for #73. After revising my approach I'm fairly certain it works correctly. I extracted a couple of functions from `normalizeBinary` for getting the relevant registry values as promises and test in turn both registry hives before falling back on the standard program files path as before.

Tested by editing the registry to the following circumstances:
- Both keys in place, opens Firefox correctly
- Only HKLM key in place, old path found as before
- Both keys missing, falls back on program files as before