### PR TITLE
chore(circleci): Added missing persist_project_repo step in build jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,7 @@ jobs:
           suffix: << parameters.nodejs >>
       - run_npm_ci
       - run: npm run test
+      - persist_project_repo
       - save_build_cache:
           suffix: << parameters.nodejs >>
 


### PR DESCRIPTION
Fixes release_tag job failure (e.g. see [this failed job](https://app.circleci.com/pipelines/github/mozilla/node-fx-runner/57/workflows/d3ad92f3-955d-4893-a97c-654e2ffcf2b4/jobs/192/parallel-runs/0/steps/0-104)), due to missing a project checkout to publish on npm.

The underlying issue is that we are not persisting the project repo in the build steps, which are the ones that are actively checking out the project sources, as an example as we do in the [webextension-polyfill circleci config here](https://github.com/mozilla/webextension-polyfill/blob/e48cc39170f558e708f7309a30cfee9ea7138be5/.circleci/config.yml#L138).