### PR TITLE
chore(circleci): persist_project_repo step should run on the build running on nodejs_current

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,13 @@ jobs:
           suffix: << parameters.nodejs >>
       - run_npm_ci
       - run: npm run test
-      - persist_project_repo
+      ## Only persist the workspace once (for the same nodejs
+      ## version that release_tag will be executed for).
+      - when:
+          condition:
+            equal: [*nodejs_current, << parameters.nodejs >>]
+          steps:
+            - persist_project_repo
       - save_build_cache:
           suffix: << parameters.nodejs >>
 


### PR DESCRIPTION
Should fix failure triggered in the last run for the release_tag job (see [failure log here](https://app.circleci.com/pipelines/github/mozilla/node-fx-runner/60/workflows/61cd65a2-b787-4ba1-ac37-3b09446e177a/jobs/202/parallel-runs/0/steps/0-101)).

We do the [same for web-ext](https://github.com/mozilla/web-ext/blob/d07b9238ed91c9bc8f475d9890b0509e12fe4350/.circleci/config.yml#L213), because unlike webextension-polyfill both node-fx-runner and web-ext circle-ci jobs runs on more than one nodejs version as in this case.