### PR TITLE
chore: Updated package.json metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,13 +16,9 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/mozilla-jetpack/node-fx-runner"
+    "url": "git://github.com/mozilla/node-fx-runner"
   },
-  "author": {
-    "name": "Erik Vold",
-    "email": "evold@mozilla.com",
-    "url": "http://work.erikvold.com/"
-  },
+  "author": "Mozilla Add-ons Team",
   "license": "MPL-2.0",
   "dependencies": {
     "commander": "2.9.0",
@@ -38,15 +34,5 @@
     "dive": "0.5.0",
     "mocha": "8.3.0",
     "sandboxed-module": "2.0.4"
-  },
-  "maintainers": [
-    {
-      "name": "erikvold",
-      "email": "erikvvold@gmail.com"
-    },
-    {
-      "name": "jsantell",
-      "email": "jsantell@mozilla.com"
-    }
-  ]
+  }
 }


### PR DESCRIPTION
While I was releasing v1.1.0 yesterday I did notice that the package metadata could use an update.

In this PR:
- updated the repo url to remove link to the obsolete mozilla-jetpack organization (the url was redirected to the new one, but it does still make sense to update it to point directly to the repo in the mozilla organization)
- set the author field to `"Mozilla Add-ons Team"` (like in the addons-linter package.json file)
- I removed the maintainers field (npm should be automatically setting it to the npm login that publish the releases)
 
I was tempted to move the previous list of mantainers into the contributors field, but honestly the contributors list from the github repo (or computed from the git commits authors) is a better way to get to an updated list of contributors (and the list in the package.json file would be likely become obsolete if it is not generated with some automation, which I'm not sure it may be really worth it).