### PR TITLE
feat: add an option to change the final order of the command arguments

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -14,43 +14,13 @@ var parse = require("shell-quote").parse;
  * @param {Object} options
  *   - `binary` path to Firefox binary to use
  *   - `profile` path to profile or profile name to use
+ *   - `binary-args-first` put the binary arguments first in the list of
+ *     command arguments
  * @return {Object} results
  */
 function runFirefox (options) {
-  options = options || {};
-  var profilePath = options.profile;
-  var env = Object.assign({}, process.env, options.env || {});
-  var args = [];
-  if (profilePath) {
-    if (isProfileName(profilePath)) {
-      args.unshift("-P", profilePath);
-    }
-    else {
-      args.unshift("-profile", profilePath);
-    }
-  }
-  if (options["new-instance"]) {
-    args.unshift("-new-instance");
-  }
-  if (options["no-remote"]) {
-    args.unshift("-no-remote");
-  }
-  if (options["foreground"]) {
-    args.unshift("-foreground");
-  }
-  if (options["binary-args"]) {
-    if (Array.isArray(options["binary-args"])) {
-      args = args.concat(options["binary-args"]);
-    }
-    else {
-      args = args.concat(parse(options["binary-args"]));
-    }
-  }
-  // support for starting the remote debugger server
-  if (options["listen"]) {
-    args.unshift(options.listen);
-    args.unshift("-start-debugger-server");
-  }
+  const env = Object.assign({}, process.env, options.env || {});
+  const args = buildArgs(options || {});
 
   return normalizeBinary(options.binary).then(function(binary) {
     // Using `spawn` so we can stream logging as they come in, rather than
@@ -85,3 +55,50 @@ function isProfileName (profile) {
   }
   return !/[\\\/]/.test(profile);
 }
+
+function buildArgs(options) {
+  let args = [];
+
+  const profilePath = options.profile;
+
+  if (profilePath) {
+    if (isProfileName(profilePath)) {
+      args.unshift("-P", profilePath);
+    }
+    else {
+      args.unshift("-profile", profilePath);
+    }
+  }
+
+  if (options["new-instance"]) {
+    args.unshift("-new-instance");
+  }
+
+  if (options["no-remote"]) {
+    args.unshift("-no-remote");
+  }
+
+  if (options["foreground"]) {
+    args.unshift("-foreground");
+  }
+
+  // support for starting the remote debugger server
+  if (options["listen"]) {
+    args.unshift(options.listen);
+    args.unshift("-start-debugger-server");
+  }
+
+  if (options["binary-args"]) {
+    const binaryArgs = Array.isArray(options["binary-args"]) ?
+      options["binary-args"] : parse(options["binary-args"]);
+
+    if (options["binary-args-first"]) {
+      args = binaryArgs.concat(args);
+    } else {
+      args = args.concat(binaryArgs);
+    }
+  }
+
+  return args;
+}
+module.exports.buildArgs = buildArgs;

--- a/lib/run.js
+++ b/lib/run.js
@@ -15,7 +15,8 @@ var parse = require("shell-quote").parse;
  *   - `binary` path to Firefox binary to use
  *   - `profile` path to profile or profile name to use
  *   - `binary-args-first` put the binary arguments first in the list of
- *     command arguments
+ *     command arguments. This is mainly useful to be able to run binaries via
+ *     third-party tools, e.g. `flatpak run org.mozilla.firefox`.
  * @return {Object} results
  */
 function runFirefox (options) {

--- a/test/run/test.run.js
+++ b/test/run/test.run.js
@@ -11,6 +11,7 @@ var expect = chai.expect;
 var exec = utils.exec;
 var isWindows = /^win/.test(process.platform);
 var normalizeBinary = require("../../lib/utils").normalizeBinary;
+var run = require("../../lib/run");
 var cp = require("child_process");
 var parse = require("shell-quote").parse;
 
@@ -124,4 +125,35 @@ describe("concat binary arguments", function () {
     expect(arr[2]).to.be.equal("-c");
     expect(arr[3]).to.be.equal("d e");
   });
+});
+
+describe("buildArgs", () => {
+  it("returns a list of arguments", () => {
+    const options = {
+      foreground: true,
+      'binary-args': ["-a", 1, "-b", "--long-flag"],
+    };
+    expect(run.buildArgs(options)).to.be.eql([
+      "-foreground",
+      "-a",
+      1,
+      "-b",
+      "--long-flag",
+    ]);
+  });
+
+  it("puts the binary args first when `binary-args-first` is `true`", () => {
+    const options = {
+      foreground: true,
+      'binary-args': ["run", "app", "--long-flag"],
+      'binary-args-first': true,
+    };
+    expect(run.buildArgs(options)).to.be.eql([
+      "run",
+      "app",
+      "--long-flag",
+      "-foreground",
+    ]);
+  });
+
 });


### PR DESCRIPTION
I decided to add a new parameter to be backward compatible just in case.. I don't think it matters much but also I don't know the history of the project and it feels weird to add parameters at the beginning of the list (with `unshift()`). There might be a reason..