### PR TITLE
Fix Firefox ESR variant not found on Windows (fix #112)

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -96,6 +96,8 @@ function getPathToExe(hive, appName) {
 
   return getRegistryValue(hive, rootKey, "CurrentVersion").then(function(version) {
     return getRegistryValue(hive, path.join(rootKey, version, "Main"), "PathToExe");
+  }).catch(function() {  // fallback on checking for latest version on multi-version or ESR installs
+    return findLatestVersionExePath(hive, rootKey);
   });
 }
 
@@ -107,6 +109,27 @@ function getRegistryValue(hive, key, name) {
     registry.get(name, function(error, resultKey) {
       if (resultKey && !error) {
         resolve(resultKey.value);
+      } else {
+        reject(error);
+      }
+    });
+  });
+}
+
+// ESR is registered using the multi-version scheme; under a subkey: <hive>\SOFTWARE\Mozilla\Mozilla Firefox\<version-key>
+// E.g. HKLM\SOFTWARE\Mozilla\Mozilla Firefox\115.11.0 ESR (x64 en-US)
+function findLatestVersionExePath(hive, key) {
+  return when.promise(function(resolve, reject) {
+    const ffKey = new Winreg({ hive, key });
+    ffKey.keys(function(error, subKeys) {
+      if (!error && subKeys.length > 0) {
+        const latestVersionKey = subKeys.sort(function(a,b) {  // reverse sort
+          return b.path.localeCompare(a.path);
+        })[0];
+        const subKeyPath = latestVersionKey.path.replace(hive, '');  // strip the hive prefix so we can re-use getRegistryValue
+        resolve(getRegistryValue(hive, path.join(subKeyPath, "Main"), "PathToExe"));
+      } else if (!error) {
+        reject("No Firefox version sub-keys found under: " + ffKey.path);
       } else {
         reject(error);
       }


### PR DESCRIPTION
Resolves #112.

I don't have nightly as mentioned in #31 , but was getting the same error using a ESR version of FF.
This fix _may_ resolve the nightly issue as well, provided nightly also installs like ESR. If someone with nightly can test if the fix also resolves the nightly issue, that'd be great.