### PR TITLE
feat(lib/utils.js): support firefox esr

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -40,7 +40,7 @@ function normalizeBinary (binaryPath, platform, arch) {
     if (platform === "osx") {
       var result = null;
       var channelNames = [
-        "firefox", "firefoxdeveloperedition", "beta", "nightly", "aurora"
+        "firefox", "firefoxdeveloperedition", "beta", "nightly", "aurora", "esr"
       ];
 
       if (channelNames.indexOf(binaryPath) !== -1) {
@@ -121,6 +121,7 @@ normalizeBinary.paths = {
   "firefoxdeveloperedition on osx": "/Applications/Firefox Developer Edition.app/Contents/MacOS/firefox",
   "aurora on osx": "/Applications/FirefoxAurora.app/Contents/MacOS/firefox",
   "nightly on osx": "/Applications/Firefox Nightly.app/Contents/MacOS/firefox",
+  "esr on osx": "/Applications/Firefox ESR.app/Contents/MacOS/firefox",
 };
 
 normalizeBinary.appNames = {
@@ -129,12 +130,14 @@ normalizeBinary.appNames = {
   "aurora on linux": "firefox-aurora",
   "firefoxdeveloperedition on linux": "firefox-developer-edition",
   "nightly on linux": "firefox-nightly",
+  "esr on linux": "firefox-esr",
   "firefox on windows": "Mozilla Firefox",
   // the default path in the beta installer is the same as the stable one
   "beta on windows": "Mozilla Firefox",
   "firefoxdeveloperedition on windows": "Firefox Developer Edition",
   "aurora on windows": "Aurora",
-  "nightly on windows": "Nightly"
+  "nightly on windows": "Nightly",
+  "esr on windows": "Mozilla Firefox ESR"
 };
 
 exports.normalizeBinary = normalizeBinary;

--- a/test/run/test.utils.js
+++ b/test/run/test.utils.js
@@ -233,7 +233,9 @@ describe("lib/utils", function () {
       [["nightly", "windows", "x86"], "nightly"],
       [["nightly", "windows", "x86_64"], "nightly"],
       [["aurora", "windows", "x86"], "aurora"],
-      [["aurora", "windows", "x86_64"], "aurora"]
+      [["aurora", "windows", "x86_64"], "aurora"],
+      [["esr", "windows", "x86"], "Mozilla Firefox ESR"],
+      [["esr", "windows", "x86_64"], "Mozilla Firefox ESR"]
     ].map(function(fixture) {
       var promise = binary.apply(binary, fixture[args]);
       return promise.then(function(actual) {
@@ -268,6 +270,9 @@ describe("lib/utils", function () {
 
       [["nightly", "linux", "x86_64"], "/usr/bin/firefox-nightly"],
       [["nightly", "linux", "x86_64"], "/usr/bin/firefox-nightly"],
+
+      [["esr", "linux", "x86"], "/usr/bin/firefox-esr"],
+      [["esr", "linux", "x86_64"], "/usr/bin/firefox-esr"],
     ].map(function(fixture) {
       var promise = binary.apply(binary, fixture[args]);
       return promise.then(function(actual) {
@@ -298,7 +303,10 @@ describe("lib/utils", function () {
       [["aurora", "darwin", "x86_64"], "/Applications/FirefoxAurora.app/Contents/MacOS/firefox"],
 
       [["nightly", "darwin", "x86"], "/Applications/Firefox Nightly.app/Contents/MacOS/firefox"],
-      [["nightly", "darwin", "x86_64"], "/Applications/Firefox Nightly.app/Contents/MacOS/firefox"]
+      [["nightly", "darwin", "x86_64"], "/Applications/Firefox Nightly.app/Contents/MacOS/firefox"],
+
+      [["esr", "darwin", "x86"], "/Applications/Firefox ESR.app/Contents/MacOS/firefox"],
+      [["esr", "darwin", "x86_64"], "/Applications/Firefox ESR.app/Contents/MacOS/firefox"]
     ].map(function (fixture) {
       var promise = binary.apply(binary, fixture[args]);
       return promise.then(function(actual) {

--- a/test/run/test.utils.js
+++ b/test/run/test.utils.js
@@ -222,6 +222,9 @@ describe("lib/utils", function () {
         if (options.key.toLowerCase().indexOf("aurora") != -1) {
           value = "aurora";
         }
+        if (options.key.toLowerCase().indexOf("esr") != -1) {
+          value = "Mozilla Firefox ESR";
+        }
         this.get = function(_, fn) {
           fn(null, {value: value});
         };


### PR DESCRIPTION
Fixes #112 

This PR adds support for detecting Firefox ESR binaries across macOS, Windows, and Linux, and cleans up `utils.js` for improved readability and maintainability.

#### User Impact

- Users can now specify `-b esr` or `esr` as the binary option, and the runner will resolve the appropriate Firefox ESR binary for their operating system.
- This enhancement ensures parity with other supported Firefox channels (e.g., Beta, Nightly, Developer Edition).

~~#### Code Modernization~~

~~- Replaced legacy function expressions with arrow functions where appropriate.~~
~~- Prefixed Node.js built-in modules with `node:` per current Node.js convention.~~
~~- Removed redundant `"use strict"` directives, as they are unnecessary in current Node.js environments.~~
~~- Refactored template strings in place of string concatenation for improved clarity.~~